### PR TITLE
Feat/send signing score

### DIFF
--- a/lib/screens/practice/signing_screen.dart
+++ b/lib/screens/practice/signing_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'dart:async';
 import 'dart:convert';
+import 'package:flutter_hands/services/auth_service.dart';
+
 import '../../main.dart';
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
@@ -45,6 +47,8 @@ class _SigningScreenState extends State<SigningScreen>
   Timer? _progressTimer;
   bool _isProgressVisible = false;
   final int totalDurationInSeconds = 3;
+
+  int _signingScore = 0;
 
   final String instructions =
       """1. Look at the number word on the screen (like "Three").
@@ -339,13 +343,16 @@ class _SigningScreenState extends State<SigningScreen>
   void _handleAnswer(int handSign) {
     setState(() {
       final isCorrect = _signingController.checkAnswer(handSign);
+      if (isCorrect) {
+        _signingScore++; // Increment the signing score if the answer is correct
+      }
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(isCorrect ? 'Correct!' : 'Incorrect!'),
           duration: const Duration(seconds: 1),
           behavior: SnackBarBehavior.floating,
-          backgroundColor: isCorrect?Colors.teal : Colors.red  ,
+          backgroundColor: isCorrect ? Colors.teal : Colors.red,
           margin: const EdgeInsets.all(50),
           elevation: 30,
         ),
@@ -364,7 +371,36 @@ class _SigningScreenState extends State<SigningScreen>
     });
   }
 
+  Future<void> _sendScoreToAPI(int score) async {
+    String apiUrl = 'http://${GlobalVariables.server}/save_score/'; // Replace with your actual endpoint
+    final userData = await AuthService.getUserData(); 
+
+    try {
+      final response = await http.post(
+        Uri.parse(apiUrl),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: json.encode({
+          'username': userData?['username'], // Replace with the actual username or user ID
+          'signing_score': score,
+        }),
+      );
+
+      if (response.statusCode == 200) {
+        print('Score saved successfully: ${response.body}');
+      } else {
+        throw Exception('Failed to save score: ${response.statusCode}');
+      }
+    } catch (e) {
+      print('Error saving score: $e');
+    }
+  }
+
   void _showResults() {
+    // Send the signing score to the backend
+    _sendScoreToAPI(_signingScore);
+
     showDialog(
       context: context,
       barrierDismissible: false,

--- a/lib/screens/practice/signing_screen.dart
+++ b/lib/screens/practice/signing_screen.dart
@@ -1,11 +1,13 @@
 import 'dart:io';
 import 'dart:async';
 import 'dart:convert';
+import 'package:flutter_hands/services/auth_service.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import '../../main.dart';
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
-import 'package:flutter_hands/services/auth_service.dart';
 import 'package:flutter_hands/base/res/styles/app_styles.dart';
 import 'package:flutter_hands/controllers/signing_controller.dart';
 import 'package:flutter_hands/base/res/global/global_variables.dart';
@@ -48,6 +50,7 @@ class _SigningScreenState extends State<SigningScreen>
   final int totalDurationInSeconds = 3;
 
   int _signingScore = 0;
+  static const _storage = FlutterSecureStorage();
 
   final String instructions =
       """1. Look at the number word on the screen (like "Three").
@@ -370,44 +373,40 @@ class _SigningScreenState extends State<SigningScreen>
     });
   }
 
+  static Future<String?> getToken() async {
+    return await _storage.read(key: 'token');
+  }
+
   Future<void> _sendScoreToAPI(int score) async {
+    String apiUrl = 'http://${GlobalVariables.server}/api/auth/save_score/'; // Replace with your actual endpoint
+    final userData = await AuthService.getUserData(); 
+    final token =  await getToken();
     try {
-      // Comprehensive logging
-      print('Attempting to send score: $score');
-
-      final userData = await AuthService.getUserData();
-      final token = await AuthService.getToken();
-
       final response = await http.post(
-        Uri.parse('http://${GlobalVariables.server}/api/auth/save_score/'),
+        Uri.parse(apiUrl),
         headers: {
           'Content-Type': 'application/json',
           'Authorization': 'Token $token',
         },
         body: json.encode({
-          'username': userData?['username'],
+          'username': userData?['username'], // Replace with the actual username or user ID
           'signing_score': score,
         }),
       );
 
-
       if (response.statusCode == 200) {
-        print('Score saved successfully');
+        print('Score saved successfully: ${response.body}');
       } else {
-        print('Failed to save score');
-        throw Exception('Score save failed: ${response.statusCode}');
+        throw Exception('Failed to save score: ${response.statusCode}');
       }
     } catch (e) {
-      // Detailed error logging
-      print('Complete Error Details:');
-      print('Error Type: ${e.runtimeType}');
-      print('Error Message: $e');
+      print('Error saving score: $e');
     }
   }
 
   void _showResults() {
     // Send the signing score to the backend
-    _sendScoreToAPI(_signingController.score);
+    _sendScoreToAPI(_signingScore);
 
     showDialog(
       context: context,

--- a/lib/screens/practice/signing_screen.dart
+++ b/lib/screens/practice/signing_screen.dart
@@ -1,12 +1,11 @@
 import 'dart:io';
 import 'dart:async';
 import 'dart:convert';
-import 'package:flutter_hands/services/auth_service.dart';
-
 import '../../main.dart';
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:flutter_hands/services/auth_service.dart';
 import 'package:flutter_hands/base/res/styles/app_styles.dart';
 import 'package:flutter_hands/controllers/signing_controller.dart';
 import 'package:flutter_hands/base/res/global/global_variables.dart';
@@ -372,34 +371,43 @@ class _SigningScreenState extends State<SigningScreen>
   }
 
   Future<void> _sendScoreToAPI(int score) async {
-    String apiUrl = 'http://${GlobalVariables.server}/save_score/'; // Replace with your actual endpoint
-    final userData = await AuthService.getUserData(); 
-
     try {
+      // Comprehensive logging
+      print('Attempting to send score: $score');
+
+      final userData = await AuthService.getUserData();
+      final token = await AuthService.getToken();
+
       final response = await http.post(
-        Uri.parse(apiUrl),
+        Uri.parse('http://${GlobalVariables.server}/api/auth/save_score/'),
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': 'Token $token',
         },
         body: json.encode({
-          'username': userData?['username'], // Replace with the actual username or user ID
+          'username': userData?['username'],
           'signing_score': score,
         }),
       );
 
+
       if (response.statusCode == 200) {
-        print('Score saved successfully: ${response.body}');
+        print('Score saved successfully');
       } else {
-        throw Exception('Failed to save score: ${response.statusCode}');
+        print('Failed to save score');
+        throw Exception('Score save failed: ${response.statusCode}');
       }
     } catch (e) {
-      print('Error saving score: $e');
+      // Detailed error logging
+      print('Complete Error Details:');
+      print('Error Type: ${e.runtimeType}');
+      print('Error Message: $e');
     }
   }
 
   void _showResults() {
     // Send the signing score to the backend
-    _sendScoreToAPI(_signingScore);
+    _sendScoreToAPI(_signingController.score);
 
     showDialog(
       context: context,


### PR DESCRIPTION
### **Step-by-Step Explanation**

**1. Define the API URL:**
The apiUrl variable is constructed using the server address stored in GlobalVariables.server and the endpoint for saving the score (/api/auth/save_score/).

**2. Retrieve User Data:**
The method calls AuthService.getUser Data() to retrieve the current user's data, which includes the username and the token. This method should return a map containing the user's information.

**3. Retrieve the Token:**
The method calls getToken() to retrieve the authentication token from secure storage. This token is necessary for authenticating the request to the API.

**4. Prepare the HTTP POST Request:**
The method uses the http.post function to send a POST request to the API.
The request includes:
Headers:
Content-Type: Set to application/json to indicate that the request body contains JSON data.
Authorization: Set to 'Token $token', which includes the token retrieved earlier. This is crucial for authenticating the request.
Body: The body of the request is created using json.encode, which converts a Dart map into a JSON string. The map contains:
username: The username of the user, retrieved from userData.
signing_score: The score that you want to send to the API.

**5. Handle the Response:**
After sending the request, the method checks the response status code:
If the status code is 200, it means the score was saved successfully, and it prints the response body.
If the status code is not 200, it throws an exception indicating that saving the score failed.

**6.Error Handling:**
The method includes a try-catch block to handle any exceptions that may occur during the request. If an error occurs, it prints an error message.